### PR TITLE
Fix memory leak and potential props clash

### DIFF
--- a/.changeset/pink-kiwis-flash.md
+++ b/.changeset/pink-kiwis-flash.md
@@ -1,0 +1,5 @@
+---
+'@threlte/test': patch
+---
+
+Fix memory leak and potential props clash

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"license": "MIT",
 	"version": "0.2.3",
 	"scripts": {
+		"all": "npm run check && npm run lint && npm run test && npm run build",
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
 		"preview": "vite preview",

--- a/src/lib/Container.svelte
+++ b/src/lib/Container.svelte
@@ -14,6 +14,9 @@
 	/** @type {typeof import('svelte').SvelteComponent} */
 	export let component
 
+	/** @type {Record<string, unknown> | undefined} */
+	export let componentProps
+
 	/** @type {import('svelte').SvelteComponent | undefined} */
 	export let ref = undefined
 
@@ -65,5 +68,5 @@
 </script>
 
 <SceneGraphObject object={threlteContext.scene}>
-	<svelte:component this={component} bind:this={ref} {...$$restProps} />
+	<svelte:component this={component} bind:this={ref} {...componentProps} />
 </SceneGraphObject>


### PR DESCRIPTION
## Overview

As discussed in person, there's a lot of overlap between `@threlte/test` and the vanilla [@testing-library/svelte](https://github.com/testing-library/svelte-testing-library). As I was exploring integrating the two libraries more closely via a peer dependency relationship, a couple little issues got in my way that I figured I'd put a PR up for

## Change log

- Remove memory leak of `canvas` elements getting added to a `Set` but never removed
    - There didn't appear to be any actual cleanup needed, so I removed the `Set`
- Ensure component props can't class with container props by creating an explicitly named `componentProps` prop for the container
    - This is easier to read in the code than it is to describe in a bullet point 🫠 
- Fix a bad validity check that would've allowed an array to masquerade as an object 