### PR TITLE
fix(types): remove erroneous export in `index.d.ts`

### DIFF
--- a/.changeset/green-bananas-sit.md
+++ b/.changeset/green-bananas-sit.md
@@ -1,0 +1,5 @@
+---
+'@threlte/test': patch
+---
+
+Fix exported types

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
 	"name": "@threlte/test",
-	"version": "0.0.0",
+	"version": "0.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@threlte/test",
-			"version": "0.0.0",
+			"version": "0.2.4",
+			"license": "MIT",
 			"dependencies": {
 				"jsdom": "^24.1.0"
 			},

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -5,8 +5,6 @@ import * as THREE from 'three'
 import type { CurrentWritable, ThrelteContext } from '@threlte/core'
 import type { IntersectionEvent, interactivity } from '@threlte/extras'
 
-export { act, cleanup, render } from './pure'
-
 /** @TODO export from @threlte/extras */
 
 type ThrelteEvents =


### PR DESCRIPTION
`src/index.d.ts` has an erroneous `export` line that duplicates the type exports for `render`, `act`, and `cleanup`. This causes type checking failures in consumers in the latest version of TypeScript